### PR TITLE
Update quickstart-hashicorp-vault.template

### DIFF
--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -300,16 +300,7 @@
         "VaultLogGroup": {
             "Type": "AWS::Logs::LogGroup",
             "Properties": {
-                "LogGroupName": {
-                    "Fn::Join": [
-                        "-",
-                        [
-                            {
-                                "Ref": "AWS::StackName"
-                            },
-                            "Vault-Audit-Logs"
-                        ]
-                    ]
+                "LogGroupName": "Vault-Audit-Logs"
                 },
                 "RetentionInDays": 7
             }


### PR DESCRIPTION
Changed naming of Log-Group to be inline with awslogs-config-file, where the log_group name references to Vault-Audit-Logs instead of <Prefix-Stack-Name>-Vault-Audit-Logs