### PR TITLE
Various fixes for aws logs (CloudWatch Configs)

### DIFF
--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -20,6 +20,4 @@ tests:
     parameter_input: quickstart-hashicorp-vault.json
     template_file:  quickstart-hashicorp-vault-master.template
     regions:
-    - us-east-2
-    - eu-west-1
     - us-east-1

--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -374,7 +374,7 @@
                                         }
                                     ]
                                 },
-                                "mode": "000700",
+                                "mode": "000744",
                                 "owner": "root",
                                 "group": "root"
                             },
@@ -703,7 +703,7 @@
                                         }
                                     ]
                                 },
-                                "mode": "000700",
+                                "mode": "000744",
                                 "owner": "root",
                                 "group": "root"
                             },

--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -387,7 +387,7 @@
                         },
                         "commands": {
                             "01_create_awslogs_config_file": {
-                                "command": "sed -i \"s/__VAULT_LOG_GROUP__/${ColdCordaLogGroup}/g\" /etc/awslogs-config-file"
+                                "command": "sed -i \"s/__VAULT_LOG_GROUP__/${VaultLogGroup}/g\" /etc/awslogs-config-file"
                             },
                             "02_run_awslogs_agent_setup.py": {
                                 "command": {

--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -405,7 +405,10 @@
                         },
                         "commands": {
                             "01_create_awslogs_config_file": {
-                                "command": "sed -i \"s/__VAULT_LOG_GROUP__/${VaultLogGroup}/g\" /etc/awslogs-config-file"
+                                "command": {
+                                    "Fn::Sub": 
+                                        "sed -i s/__VAULT_LOG_GROUP__/${VaultLogGroup}/g /etc/awslogs-config-file"
+                                 }
                             },
                             "02_run_awslogs_agent_setup.py": {
                                 "command": {
@@ -703,6 +706,25 @@
                                 "mode": "000700",
                                 "owner": "root",
                                 "group": "root"
+
+                            },
+                            "/etc/awslogs-config-file": {
+                                "source": {
+                                    "Fn::Sub": [
+                                        "https://s3.amazonaws.com/${QSS3BucketName}/${QSS3KeyPrefix}scripts/awslogs-config-file",
+                                        {
+                                            "QSS3BucketName": {
+                                                "Ref": "QSS3BucketName"
+                                            },
+                                            "QSS3KeyPrefix": {
+                                                "Ref": "QSS3KeyPrefix"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "mode": "000700",
+                                "owner": "root",
+                                "group": "root"
                             },
                             "/usr/local/awslogs-agent-setup.py": {
                                 "source": "https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py",
@@ -714,8 +736,11 @@
                         "commands": {
 
                             "01_create_awslogs_config_file": {
-                                "command": "sed -i \"s/__VAULT_LOG_GROUP__/${VaultLogGroup}/g\" /etc/awslogs-config-file"
-                            },
+                                "command": {
+                                    "Fn::Sub": 
+                                        "sed -i s/__VAULT_LOG_GROUP__/${VaultLogGroup}/g /etc/awslogs-config-file"
+                                 }
+                             },
                             "02_run_awslogs_agent_setup.py": {
                                 "command": {
                                     "Fn::Sub": [

--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -694,19 +694,17 @@
                             }
                         },
                         "commands": {
-                            "01_run_awslogs_agent_setup.py": {
+
+                            "01_create_awslogs_config_file": {
+                                "command": "sed -i \"s/__VAULT_LOG_GROUP__/${VaultLogGroup}/g\" /etc/awslogs-config-file"
+                            },
+                            "02_run_awslogs_agent_setup.py": {
                                 "command": {
                                     "Fn::Sub": [
-                                        "python /usr/local/awslogs-agent-setup.py -n -r ${Region} -c https://s3.amazonaws.com/${QSS3BucketName}/${QSS3KeyPrefix}scripts/awslogs-config-file",
+                                        "python /usr/local/awslogs-agent-setup.py -n -r ${Region} -c /etc/awslogs-config-file",
                                         {
                                             "Region": {
                                                 "Ref": "AWS::Region"
-                                            },
-                                            "QSS3BucketName": {
-                                                "Ref": "QSS3BucketName"
-                                            },
-                                            "QSS3KeyPrefix": {
-                                                "Ref": "QSS3KeyPrefix"
                                             }
                                         }
                                     ]

--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -360,6 +360,24 @@
                             "/usr/local": "http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip"
                         },
                         "files": {
+                            "/etc/cron.hourly/cloudwatch-monitoring.sh": {
+                                "source": {
+                                    "Fn::Sub": [
+                                        "https://s3.amazonaws.com/${QSS3BucketName}/${QSS3KeyPrefix}scripts/cloudwatch-monitoring.sh",
+                                        {
+                                            "QSS3BucketName": {
+                                                "Ref": "QSS3BucketName"
+                                            },
+                                            "QSS3KeyPrefix": {
+                                                "Ref": "QSS3KeyPrefix"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "mode": "000700",
+                                "owner": "root",
+                                "group": "root"
+                            },
                             "/etc/awslogs-config-file": {
                                 "source": {
                                     "Fn::Sub": [
@@ -410,7 +428,7 @@
                             "04_make_mon_put_instance_data_exececutable": {
                                 "command": "chmod +x /usr/local/aws-scripts-mon/mon-put-instance-data.pl"
                             },
-                            "06_install_crontab": {
+                            "05_install_crontab": {
                                 "command": "crontab  /etc/cron.hourly/cloudwatch-monitoring.sh"
                             }
                         }

--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -428,10 +428,10 @@
                             "04_start_awslogs_service": {
                                 "command": "systemctl start awslogs"
                             },
-                            "04_make_mon_put_instance_data_exececutable": {
+                            "05_make_mon_put_instance_data_exececutable": {
                                 "command": "chmod +x /usr/local/aws-scripts-mon/mon-put-instance-data.pl"
                             },
-                            "05_install_crontab": {
+                            "06_install_crontab": {
                                 "command": "crontab  /etc/cron.hourly/cloudwatch-monitoring.sh"
                             }
                         }
@@ -706,7 +706,6 @@
                                 "mode": "000700",
                                 "owner": "root",
                                 "group": "root"
-
                             },
                             "/etc/awslogs-config-file": {
                                 "source": {
@@ -734,13 +733,12 @@
                             }
                         },
                         "commands": {
-
                             "01_create_awslogs_config_file": {
                                 "command": {
                                     "Fn::Sub": 
                                         "sed -i s/__VAULT_LOG_GROUP__/${VaultLogGroup}/g /etc/awslogs-config-file"
                                  }
-                             },
+                            },
                             "02_run_awslogs_agent_setup.py": {
                                 "command": {
                                     "Fn::Sub": [
@@ -753,16 +751,16 @@
                                     ]
                                 }
                             },
-                            "02_enable_awslogs_service": {
+                            "03_enable_awslogs_service": {
                                 "command": "systemctl enable awslogs"
                             },
-                            "03_start_awslogs_service": {
+                            "04_start_awslogs_service": {
                                 "command": "systemctl start awslogs"
                             },
-                            "04_make_mon_put_instance_data_exececutable": {
+                            "05_make_mon_put_instance_data_exececutable": {
                                 "command": "chmod +x /usr/local/aws-scripts-mon/mon-put-instance-data.pl"
                             },
-                            "05_install_crontab": {
+                            "06_install_crontab": {
                                 "command": "crontab  /etc/cron.hourly/cloudwatch-monitoring.sh"
                             }
                         }


### PR DESCRIPTION
**This PR address the following Issues:**
Fixes: https://github.com/aws-quickstart/quickstart-hashicorp-vault/issues/26
Fixes: https://github.com/aws-quickstart/quickstart-hashicorp-vault/issues/28

### Description of changes:
- Fix Empty LogGroup Name (Vault1)
- Add CloudWatch config for (Valut2)
- Reorder ConfigSets

### Fix Verification #26 
On Vault1 it has an empty log_group_name: **(fixed)**
On Vault2 it has the VAULT_LOG_GROUP token still in place: **(fixed)**
![image](https://user-images.githubusercontent.com/5912128/67132036-0ade5780-f1bc-11e9-98d6-91d39bcc8ee1.png)

### Fix Verification #28 
/etc/cron.hourly/cloudwatch-monitoring.sh but /etc/cron.hourly is empty **(fixed)**
Crontab in place
![image](https://user-images.githubusercontent.com/5912128/67132212-c8694a80-f1bc-11e9-9703-b516169f0b4e.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
