### PR TITLE
Kubernetes auth

### DIFF
--- a/scripts/bootstrap_server.sh
+++ b/scripts/bootstrap_server.sh
@@ -35,6 +35,7 @@ VAULT_URL="https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_V
 VAULT_ZIP=$(echo $VAULT_URL | rev | cut -d "/" -f 1 | rev)
 
 VAULT_STORAGE_PATH="/vault/$INSTANCE_ID"
+VAULT_LOG_PATH="/vault/log"
 
 # Install Vault
 install_vault
@@ -195,8 +196,13 @@ then
 
         sleep ${SLEEP} 
 
-        # Enable AWS Auth
+        # Login to Vault
         vault login token=$root_token 2>&1 > /dev/null  # Hide this output from the console
+
+        # Enable Vault audit logs
+        vault audit enable file file_path=${VAULT_LOG_PATH}/vault-audit.log
+
+        # Enable AWS Auth
         vault auth enable aws
 
         # Create client-role-iam role
@@ -224,9 +230,6 @@ then
                         policies=default \
                         ttl=1h
         fi
-        
-        # Enable Vault audit logs
-        vault audit enable file file_path=/vault/vault-audit.log
 
         # Take a raft snapshot
         vault operator raft snapshot save postinstall.snapshot

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -62,8 +62,12 @@ install_vault () {
   chown ${USER}:${GROUP} /usr/local/bin/vault
   mkdir -pm 0755 /etc/vault.d
   mkdir -pm 0755 ${VAULT_STORAGE_PATH}
-  chown -R vault:vault ${VAULT_STORAGE_PATH}
+  chown -R ${USER}:${GROUP} ${VAULT_STORAGE_PATH}
   chmod -R a+rwx ${VAULT_STORAGE_PATH}
+
+  mkdir -pm 0755 ${VAULT_LOG_PATH}
+  chown -R ${USER}:${GROUP} ${VAULT_LOG_PATH}
+  chmod -R a+rwx ${VAULT_LOG_PATH}
 }
 
 cloud_watch_log_config () {
@@ -72,7 +76,7 @@ cat << EOF >/etc/awslogs-config-file
 state_file = /var/awslogs/state/agent-state
 
 [/var/log/syslog]
-file = /vault/vault_audit.logs
+file = ${VAULT_LOG_PATH}/vault_audit.logs
 log_group_name = ${VAULT_LOG_GROUP}
 log_stream_name = {instance_id}
 datetime_format = %b %d %H:%M:%S

--- a/templates/quickstart-hashicorp-vault-master.template
+++ b/templates/quickstart-hashicorp-vault-master.template
@@ -112,7 +112,7 @@ Metadata:
       VaultKubernetesHostURL:
         default: "URL of the Kubernetes cluster eg - https://192.168.99.100:8443"
       VaultKubernetesCertificate:
-        default: "PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API. NOTE: Every line must end with a newline: \n"
+        default: "AWS SSM Parameter containing PEM encoded CA cert of the Kubernetes cluster"
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
 Parameters:
@@ -307,7 +307,7 @@ Parameters:
   VaultKubernetesEnable:
     Description: Enable Kubernetes Authentication and create role
     Type: String
-    Default: 'true'
+    Default: 'false'
     AllowedValues:
       - 'true'
       - 'false'
@@ -316,10 +316,10 @@ Parameters:
     Type: String
     Default: 'kube-auth-role'
   VaultKubernetesHostURL:
-    Description: "URL of the Kubernetes cluster eg - https://192.168.99.100:8443"
+    Description: "URL of the Kubernetes cluster eg: - https://192.168.99.100:8443"
     Type: String
   VaultKubernetesCertificate:
-    Description: "AWS Secrets Manager Secret name for Secret Containing Kubernetes CA certificate"
+    Description: "AWS SSM Parameter containing your Kubernetes PEM encoded CA cert"
     Type: String
 Resources:
   VPCStack:

--- a/templates/quickstart-hashicorp-vault-master.template
+++ b/templates/quickstart-hashicorp-vault-master.template
@@ -33,6 +33,10 @@ Metadata:
       - VaultNumberOfKeysForUnseal
       - VaultClientRoleName
       - VaultClientNodes
+      - VaultKubernetesEnable
+      - VaultKubernetesHostURL
+      - VaultKubernetesRoleName
+      - VaultKubernetesCertificate
     - Label:
         default: AWS Quick Start configuration
       Parameters:
@@ -101,6 +105,14 @@ Metadata:
         default: Route 53 hosted zone ID
       DomainName:
         default: Load Balancer DNS Domain Name
+      VaultKubernetesEnable:
+        default: Enable Kubernetes Authentication and create role
+      VaultKubernetesRoleName:
+        default: Internal Hashicorp Vault name for Kubernetes Authentication role
+      VaultKubernetesHostURL:
+        default: "URL of the Kubernetes cluster eg - https://192.168.99.100:8443"
+      VaultKubernetesCertificate:
+        default: "PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API. NOTE: Every line must end with a newline: \n"
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
 Parameters:
@@ -292,6 +304,23 @@ Parameters:
     Description: The Amazon Resource Name (ARN) of the SSL certificate to use for the load balancer. Use 'ACMSSLCertificateArn' if you are not using 'DomainName' and 'HostedZoneID'.
     Type: String
     Default: ''
+  VaultKubernetesEnable:
+    Description: Enable Kubernetes Authentication and create role
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  VaultKubernetesRoleName:
+    Description: Internal Hashicorp Vault name for Kubernetes Authentication role
+    Type: String
+    Default: 'kube-auth-role'
+  VaultKubernetesHostURL:
+    Description: "URL of the Kubernetes cluster eg - https://192.168.99.100:8443"
+    Type: String
+  VaultKubernetesCertificate:
+    Description: "AWS Secrets Manager Secret name for Secret Containing Kubernetes CA certificate"
+    Type: String
 Resources:
   VPCStack:
     Metadata:
@@ -389,6 +418,10 @@ Resources:
         HostedZoneID: !Ref HostedZoneID
         ACMSSLCertificateArn: !Ref ACMSSLCertificateArn 
         LoadBalancerType: !Ref LoadBalancerType 
+        VaultKubernetesEnable: !Ref VaultKubernetesEnable
+        VaultKubernetesRoleName: !Ref VaultKubernetesRoleName
+        VaultKubernetesHostURL: !Ref VaultKubernetesHostURL
+        VaultKubernetesCertificate: !Ref VaultKubernetesCertificate
 Outputs:
   BastionHost:
     Value: !GetAtt "LinuxBastionHostStack.Outputs.EIP1"
@@ -405,6 +438,12 @@ Outputs:
   VaultSecret:
     Value: !GetAtt "HashiCorpVaultStack.Outputs.VaultSecret"
     Description: The AWS Secrets Manager Secret containing the ROOT TOKEN and Recovery Secret for Hashicorp Vault.
+  VaultKMSKeyId:
+    Value: !GetAtt "HashiCorpVaultStack.Outputs.VaultKMSKeyId"
+    Description: The AWS KMS Key used to Auto Unseal Hashicorp Vault and encrypt the ROOT TOKEN and Recovery Secret.
+  VaultKMSKeyArn:
+    Value: !GetAtt "HashiCorpVaultStack.Outputs.VaultKMSKeyArn"
+    Description: The AWS KMS Key used to Auto Unseal Hashicorp Vault and encrypt the ROOT TOKEN and Recovery Secret.
   VaultLoadBalancer:
     Value: !GetAtt "HashiCorpVaultStack.Outputs.VaultLoadBalancer"
     Description: Hashicorp Vault Load Balancer address

--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -35,6 +35,10 @@ Metadata:
       - VaultNumberOfKeysForUnseal
       - VaultClientRoleName
       - VaultClientNodes
+      - VaultKubernetesEnable
+      - VaultKubernetesHostURL
+      - VaultKubernetesRoleName
+      - VaultKubernetesCertificate
     - Label:
         default: AWS Quick Start configuration
       Parameters:
@@ -103,6 +107,14 @@ Metadata:
         default: Route 53 hosted zone ID
       DomainName:
         default: Load Balancer DNS Domain Name
+      VaultKubernetesEnable:
+        default: Enable Kubernetes Authentication and create role
+      VaultKubernetesRoleName:
+        default: Internal Hashicorp Vault name for Kubernetes Authentication role
+      VaultKubernetesHostURL:
+        default: "URL of the Kubernetes cluster eg - https://192.168.99.100:8443"
+      VaultKubernetesCertificate:
+        default: "PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API. NOTE: Every line must end with a newline: \n"
 Parameters:
   VaultAMIOS:
     AllowedValues:
@@ -272,6 +284,23 @@ Parameters:
     Description: The Amazon Resource Name (ARN) of the SSL certificate to use for the load balancer. Use 'ACMSSLCertificateArn' if you are not using 'DomainName' and 'HostedZoneID'.
     Type: String
     Default: ''
+  VaultKubernetesEnable:
+    Description: Enable Kubernetes Authentication and create role
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  VaultKubernetesRoleName:
+    Description: Internal Hashicorp Vault name for Kubernetes Authentication role
+    Type: String
+    Default: 'kube-auth-role'
+  VaultKubernetesHostURL:
+    Description: "URL of the Kubernetes cluster eg - https://192.168.99.100:8443"
+    Type: String
+  VaultKubernetesCertificate:
+    Description: "AWS Secrets Manager Secret name containing PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API"
+    Type: String
 Mappings:
   LinuxAMINameMap:
     Ubuntu-1604-HVM:
@@ -394,7 +423,7 @@ Resources:
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
-  ValutServerListenerRule:
+  VaultServerListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Properties:
       ListenerArn: !Ref VaultServerListenerHTTPS
@@ -710,16 +739,19 @@ Resources:
             qs_bootstrap_pip || qs_err
             qs_aws-cfn-bootstrap || qs_err
 
-            # TODO: Fetch script from Bucket && Run
+            # Fetch bootstrap script from Bucket & Run
             export LEADER_ELECTED_SSM_PARAMETER=${VaultLeaderElectedSSM}
             export LEADER_ID_SSM_PARAMETER=${VaultLeaderSSM}
-            export VAULT_CLUSTER_MEMBERS_SSM_PARAMETER=${VaultClusterMembersSSM}
             export LEADER_SSM_PARAM=${VaultLeaderSSM}
+            export VAULT_CLUSTER_MEMBERS_SSM_PARAMETER=${VaultClusterMembersSSM}
+            export VAULT_LOG_GROUP=${VaultLogGroup}
+            
             export AWS_REGION=${AWS::Region}
             export CFN_STACK_NAME=${AWS::StackName}
             export LEADER_ELECTION_LAMBDA=${LeaderElectionLambda}
             export CLUSTER_BOOTSTRAP_LAMBDA=${ClusterBootstrapLambda}
             export KMS_KEY=${VaultKmsKey}
+            
             export VAULT_SECRET=${VaultSecret}
             export VAULT_CLIENT_ROLE=${VaultClientRole.Arn}
             export VAULT_CLIENT_ROLE_NAME=${VaultClientRoleName}
@@ -727,13 +759,20 @@ Resources:
             export VAULT_NUMBER_OF_KEYS=${VaultNumberOfKeys}
             export VAULT_NUMBER_OF_KEYS_FOR_UNSEAL=${VaultNumberOfKeysForUnseal}
 
+            export VAULT_KUBERNETES_ENABLE=${VaultKubernetesEnable}
+            export VAULT_KUBERNETES_ROLE_NAME=${VaultKubernetesRoleName}
+            export VAULT_KUBERNETES_HOST_URL=${VaultKubernetesHostURL}
+            export VAULT_KUBERNETES_CERTIFICATE=${VaultKubernetesCertificate}
+
             pip install awscli
             mkdir -p /opt/vault/policies/ /opt/vault/scripts/ /etc/vault.d/
             
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/functions.sh .
             aws s3 cp s3://${QSS3BucketName}/${QSS3KeyPrefix}scripts/bootstrap_server.sh .
             chmod +x bootstrap_server.sh
-            ./bootstrap_server.sh
+            $(which bash) -e ./bootstrap_server.sh
+            /usr/local/bin/cfn-signal -e $? --stack ${!CFN_STACK_NAME} --region ${!AWS_REGION} --resource "VaultServerAutoScalingGroup"
+
             # Signalling done from within bootstrap script
             # echo ${SomeValue} # for clean looking !Sub
           - SomeValue: "SomeValue"
@@ -1043,6 +1082,12 @@ Outputs:
   VaultClientIAMRoleName:
     Value: !Ref "VaultClientRole"
     Description: The name of the AWS IAM role linked to Hashicorp Vault.
+  VaultKMSKeyId:
+    Value: !Ref "VaultKmsKey"
+    Description: The AWS KMS Key used to Auto Unseal Hashicorp Vault and encrypt the ROOT TOKEN and Recovery Secret.
+  VaultKMSKeyArn:
+    Value: !GetAtt "VaultKmsKey.Arn"
+    Description: The AWS KMS Key used to Auto Unseal Hashicorp Vault and encrypt the ROOT TOKEN and Recovery Secret.
   VaultClientRoleId:
     Value: !Ref VaultClientRoleName
     Description: The Hashicorp Vault identifier of the AWS client role.

--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -114,7 +114,7 @@ Metadata:
       VaultKubernetesHostURL:
         default: "URL of the Kubernetes cluster eg - https://192.168.99.100:8443"
       VaultKubernetesCertificate:
-        default: "PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API. NOTE: Every line must end with a newline: \n"
+        default: "AWS SSM Parameter containing PEM encoded CA cert of the Kubernetes cluster"
 Parameters:
   VaultAMIOS:
     AllowedValues:
@@ -287,7 +287,7 @@ Parameters:
   VaultKubernetesEnable:
     Description: Enable Kubernetes Authentication and create role
     Type: String
-    Default: 'true'
+    Default: 'false'
     AllowedValues:
       - 'true'
       - 'false'
@@ -296,10 +296,10 @@ Parameters:
     Type: String
     Default: 'kube-auth-role'
   VaultKubernetesHostURL:
-    Description: "URL of the Kubernetes cluster eg - https://192.168.99.100:8443"
+    Description: "URL of the Kubernetes cluster eg: - https://192.168.99.100:8443"
     Type: String
   VaultKubernetesCertificate:
-    Description: "AWS Secrets Manager Secret name containing PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API"
+    Description: "AWS SSM Parameter containing your Kubernetes PEM encoded CA cert"
     Type: String
 Mappings:
   LinuxAMINameMap:


### PR DESCRIPTION
*#47*

Added a mechanism to allow for Kubernetes Auth to be enabled and create a role linked to a provided Kubernetes cluster: 

**Relevant CloudFormation Parameters:**
**VaultKubernetesEnable:** 'true'
**VaultKubernetesRoleName:** 'my-role-name-here'
**VaultKubernetesHostURL:** 'https://192.168.99.100:8443'
**VaultKubernetesCertificate:** 'my-ssm-parameter-here'

**Note:** 
**VaultKubernetesHostURL:** Must be accessible from the vault cluster
**VaultKubernetesCertificate:** This is the name of the SSM Parameter containing your kubernetes clusters CA certificate

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
