### PR TITLE
Fix bootstrap script to only run iptables on the CIS AMI

### DIFF
--- a/scripts/bootstrap_server.sh
+++ b/scripts/bootstrap_server.sh
@@ -41,8 +41,23 @@ VAULT_LOG_PATH="/vault/log"
 install_vault
 
 # Allow local firewall Access (Required to open local FW access for Vault Server on CIS images) 
-iptables -I INPUT 6 -p tcp -m tcp --dport 8200 -j ACCEPT 2>&1 > /dev/null
-iptables -I INPUT 7 -p tcp -m tcp --dport 8201 -j ACCEPT 2>&1 > /dev/null
+# Test if we are on CIS or ubuntu
+CIS=$(systemctl | grep ufw | grep exited)
+if [ "${CIS}X" = "X" ]
+then
+        echo "CIS Instance setting iptables rules"
+        CIS=0
+else
+        echo "Ubuntu no need for iptables rules"
+        CIS=1
+fi
+
+if [ $CIS -eq 0 ]
+then
+
+        iptables -I INPUT 6 -p tcp -m tcp --dport 8200 -j ACCEPT 2>&1 > /dev/null
+        iptables -I INPUT 7 -p tcp -m tcp --dport 8201 -j ACCEPT 2>&1 > /dev/null
+fi
 
 # Create systemd service file for Vault
 vault_systemctl_file


### PR DESCRIPTION
*Adjust bootstrap script to only run iptables update on CIS AMI's*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
