### PR TITLE
Fix to allow for ACMSSLCertificateArn to be used instead of Created

### DIFF
--- a/templates/quickstart-hashicorp-vault-master.template
+++ b/templates/quickstart-hashicorp-vault-master.template
@@ -297,13 +297,15 @@ Parameters:
     Type: String
     Description: The fully qualified domain name for the Hashicorp Vault load balancer. Use with 'HostedZoneID' if you are not using SSL.
     MaxLength: 128
+    Default: ""
   HostedZoneID:
-    Type: AWS::Route53::HostedZone::Id
+    Type: String
     Description: Route 53 Hosted Zone ID of the domain name. Used in conjunction with 'DomainName'.
+    Default: ""
   ACMSSLCertificateArn:
     Description: The Amazon Resource Name (ARN) of the SSL certificate to use for the load balancer. Use 'ACMSSLCertificateArn' if you are not using 'DomainName' and 'HostedZoneID'.
     Type: String
-    Default: ''
+    Default: ""
   VaultKubernetesEnable:
     Description: Enable Kubernetes Authentication and create role
     Type: String

--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -277,9 +277,11 @@ Parameters:
     Type: String
     Description: The fully qualified domain name for the Hashicorp Vault load balancer. Use with 'HostedZoneID' if you are not using SSL.
     MaxLength: 128
+    Default: ""
   HostedZoneID:
-    Type: AWS::Route53::HostedZone::Id
+    Type: String
     Description: Route 53 Hosted Zone ID of the domain name. Used in conjunction with 'DomainName'.
+    Default: ""
   ACMSSLCertificateArn:
     Description: The Amazon Resource Name (ARN) of the SSL certificate to use for the load balancer. Use 'ACMSSLCertificateArn' if you are not using 'DomainName' and 'HostedZoneID'.
     Type: String


### PR DESCRIPTION
*Fix to allow for ACMSSLCertificateArn to be used instead of HostedZoneID and DomainName*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
