### PR TITLE
fix parameter checking for domain name/hosted id zone

### DIFF
--- a/templates/quickstart-hashicorp-vault-master.template
+++ b/templates/quickstart-hashicorp-vault-master.template
@@ -484,13 +484,13 @@ Outputs:
 Rules:
   DomainNamePresentWithHostedID:
     RuleCondition:
-      !Equals [ !Ref HostedZoneID, '' ]
+      !Not [!Equals [ !Ref HostedZoneID, '' ]]
     Assertions:
       - Assert: !Not [!Equals [!Ref DomainName, '']]
         AssertDescription: "Please specify a 'Domain Name' if you specify 'Route 53 Hosted Zone ID'"
   HostedIDPresentWithDomainName:
     RuleCondition:
-      !Equals [ !Ref DomainName, '' ]
+      !Not [!Equals [ !Ref DomainName, '' ]]
     Assertions:
       - Assert: !Not [!Equals [!Ref HostedZoneID, '']]
         AssertDescription: "Please specify a 'Route 53 Hosted Zone ID' if you specify 'Domain Name'"


### PR DESCRIPTION
the parameter checking is such that when no hosted id zone is present,
the stack will fail when the domain name is also not present. the same
is true in the reverse direction: when no domain name is specified, the
stack fails if no hosted id zone is present.

this change fixes the checks such that the assertions only come into
play when the initial field *is* present. for example, if the
hosted id zone *is* present, then the domain name must also be present.
similarly, when the domain name is present, the hosted id zone must
also be.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
