### PR TITLE
Updated the python runtime to 3.9 (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv/
 tmp/
 taskcat_outputs/
 functions/packages/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv/
 .taskcat_overrides.yml
 tmp/
 taskcat_outputs/
+functions/packages/

--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -858,7 +858,7 @@ Resources:
             - - !Ref QSS3KeyPrefix
               - "functions/packages/LeaderElection/lambda.zip"
       Handler: "lambda_function.lambda_handler"
-      Runtime: python3.6
+      Runtime: python3.9
       Environment:
         Variables:
           LeaderElectedSSM: !Ref VaultLeaderElectedSSM
@@ -922,7 +922,7 @@ Resources:
           LeaderSSM: !Ref VaultLeaderElectedSSM
           ClusterMembersSSM: !Ref VaultClusterMembersSSM
           AutoScalingGroup: !Sub "VaultServerAutoScalingGroup-${AWS::StackName}"
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 300
       Role: !GetAtt ClusterBootstrapLambdaExecutionRole.Arn
   ClusterBootstrapLambdaExecutionRole:

--- a/templates/quickstart-hashicorp-vault.template
+++ b/templates/quickstart-hashicorp-vault.template
@@ -562,6 +562,10 @@ Resources:
       SecretString: "empty"
   VaultKmsKey:
     Type: AWS::KMS::Key
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [EKMSKeyEnableKeyRotation, EIAMPolicyActionWildcard, EIAMPolicyWildcardResource]
     Properties:
       Description: "Vault Seal/Unseal key"
       KeyPolicy:
@@ -660,6 +664,10 @@ Resources:
       Value: "{[]}"
   VaultInstanceRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [EIAMPolicyActionWildcard, EIAMPolicyWildcardResource]
     Properties:
       RoleName: !Sub "VaultInstanceRole-${VaultSecGroup}"
       AssumeRolePolicyDocument:
@@ -868,6 +876,10 @@ Resources:
       Role: !GetAtt LeaderElectionLambdaExecutionRole.Arn
   LeaderElectionLambdaExecutionRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [EIAMPolicyActionWildcard, EIAMPolicyWildcardResource]
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -927,6 +939,10 @@ Resources:
       Role: !GetAtt ClusterBootstrapLambdaExecutionRole.Arn
   ClusterBootstrapLambdaExecutionRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [EIAMPolicyActionWildcard, EIAMPolicyWildcardResource]
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -1077,6 +1093,10 @@ Resources:
       - Ref: VaultClientRole
   VaultClientRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [EIAMPolicyActionWildcard, EIAMPolicyWildcardResource]
     Properties:
       # This example allows for an EC2 instance to assume this role. This should be customized for where the Role is being used. Eg: Lambda/Codebuild/EC2 etc.
       AssumeRolePolicyDocument:


### PR DESCRIPTION
The python runtime version 3.6 is not supported by AWS anymore and the cloud formation template results in a failure due to unsupported runtime version. The AWS recommended runtime is 3.9.

*Issue #, if available:*
https://github.com/aws-quickstart/quickstart-hashicorp-vault/issues/115

*Description of changes:*
Only modified the version in the `templates/quickstart-hashicorp-vault.template` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
